### PR TITLE
Use portalId even if not in development

### DIFF
--- a/src/utils/helpers.utils.ts
+++ b/src/utils/helpers.utils.ts
@@ -2,7 +2,7 @@ import os from 'os'
 import { argv } from 'yargs'
 
 export const fetchPortalId = () => {
-    if(process.env.NODE_ENV === 'development' && argv.portalId) return argv.portalId as string
+    if(argv.portalId) return argv.portalId as string
 
     return os.hostname().split('-')[1] as string
 }

--- a/src/utils/helpers.utils.ts
+++ b/src/utils/helpers.utils.ts
@@ -6,5 +6,6 @@ export const fetchPortalId = () => {
 
     const machineId = os.hostname().split('-')[1]
     if(!machineId) return os.hostname() as string
+    
     return machineId as string
 }

--- a/src/utils/helpers.utils.ts
+++ b/src/utils/helpers.utils.ts
@@ -4,5 +4,7 @@ import { argv } from 'yargs'
 export const fetchPortalId = () => {
     if(argv.portalId) return argv.portalId as string
 
-    return os.hostname().split('-')[1] as string
+    const machineId = os.hostname().split('-')[1]
+    if(!machineId) return os.hostname() as string
+    return machineId as string
 }


### PR DESCRIPTION
This should fix issues such as crybapp/portals#8, especially since manual mode suggests to use portalId, which is completely ignored if we're running in development.

Using hostname is not convenient especially if we're running multiple VMs in only a machine, so it's better to use portalId. Still there might be problems if portalId gets missed somehow, but should be okay for now as the main issue gets fixed.