### PR TITLE
Chromium dark mode

### DIFF
--- a/configs/chromium_policy.json
+++ b/configs/chromium_policy.json
@@ -6,14 +6,12 @@
         "chrome://policy"
     ],
     "ExtensionInstallWhitelist": [
-        "aghfnjkcakhmadgdomlmlhhaocbkloab",
         "cjpalhdlnbpafiamejdnhcphjbkeiagm"
     ],
     "ExtensionInstallBlacklist": [
         "*"
     ],
     "ExtensionInstallForcelist": [
-        "aghfnjkcakhmadgdomlmlhhaocbkloab",
         "cjpalhdlnbpafiamejdnhcphjbkeiagm"
     ]
 }

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -65,6 +65,7 @@ export const chromium = (env: NodeJS.ProcessEnv) => spawn('sudo', [
     '-no-sandbox',
     '-disable-gpu',
     '-start-maximized',
+    '-force-dark-mode',
     '-disable-file-system',
     '-disable-software-rasterizer',
 


### PR DESCRIPTION
Currently, Chromium is installing the theme "Just Black". With this PR, Chromium will start in dark mode natively without any themes.