### PR TITLE
configs/chromium_policy: disable BookmarkBar

### DIFF
--- a/configs/chromium_policy.json
+++ b/configs/chromium_policy.json
@@ -1,6 +1,7 @@
 {
     "AllowFileSelectionDialogs": false,
     "PromptForDownloadLocation": false,
+    "BookmarkBarEnabled": false,
     "URLBlacklist": [
         "file://*",
         "chrome://policy"


### PR DESCRIPTION
The bookmark bar isn't needed imo and takes away some space.