### PR TITLE
Fix start.sh execution error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+start.sh text eol=lf


### PR DESCRIPTION
If the start.sh line ending format is CR LF, the script will fail to execute and throw an error that most people will not understand. This .gitattributes file fixes the issue by ensuring the format is LF.