### PR TITLE
Added additional Browser-Extensions & -Policy's

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ To run `@cryb/portal` in development mode on Docker, run `yarn docker:dev`.
 
 Use `yarn docker:build` to build an image for deployment in production.
 
+### Chromium Extensions
+
+#### Installing Extensions
+To install Extensions into the Chromium Webbrowser of your Cryb instances, add the ID of the Extension in Question to `configs/chromium_policy.json` under `"ExtensionInstallWhitelist"` and `"ExtensionInstallForcelist"`.
+The new Extensions should now be installed by default.
+
+#### Recommended Extensions
+Here are a few Extensions recommended in certain Use-Cases:
+
+| Name | ID | Chrome Webstore Link | Recommended Use-Case |
+|---------------------|----------------------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| The Great Suspender | klbibkeccnjlkjkiokjodocebajanakg | https://chrome.google.com/webstore/detail/the-great-suspender/klbibkeccnjlkjkiokjodocebajanakg | This can improve performance, if your Cryb instances have unused tabs running in the background for hours on end |
+| Dark Reader | eimadpbcbfnmbkopoojfekhnkhdbieeh | https://chrome.google.com/webstore/detail/dark-reader/eimadpbcbfnmbkopoojfekhnkhdbieeh | Adds Dark Mode to Websites, that don't have one. Has the potential to break Websites |
+
 ## Questions / Issues
 
 If you have an issues with `@cryb/portal`, please either open a GitHub issue, or contact a maintainer.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Use `yarn docker:build` to build an image for deployment in production.
 ### Chromium Extensions
 
 #### Installing Extensions
-To install Extensions into the Chromium Webbrowser of your Cryb instances, add the ID of the Extension in Question to `configs/chromium_policy.json` under `"ExtensionInstallWhitelist"` and `"ExtensionInstallForcelist"`.
-The new Extensions should now be installed by default.
+To install any extra extensions into the Chromium browser of your Cryb instances, add the ID of the extension in question to `configs/chromium_policy.json` under `"ExtensionInstallWhitelist"` and `"ExtensionInstallForcelist"`.
+The new extension should now be installed by default.
 
 #### Recommended Extensions
 Here are a few Extensions recommended in certain Use-Cases:

--- a/configs/chromium_policy.json
+++ b/configs/chromium_policy.json
@@ -7,12 +7,23 @@
         "chrome://policy"
     ],
     "ExtensionInstallWhitelist": [
-        "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm", // uBlock Origin
+        "gcbommkclmclpchllfjekcdonpmejbdp", // HTTPS Everywhere
+        "klbibkeccnjlkjkiokjodocebajanakg", // The Great Suspender
+        "eimadpbcbfnmbkopoojfekhnkhdbieeh"  // Dark Reader (optional, 'cause it can break Websites)
     ],
     "ExtensionInstallBlacklist": [
         "*"
     ],
     "ExtensionInstallForcelist": [
-        "cjpalhdlnbpafiamejdnhcphjbkeiagm"
-    ]
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm", // uBlock Origin
+        "klbibkeccnjlkjkiokjodocebajanakg", // The great Suspender
+        "gcbommkclmclpchllfjekcdonpmejbdp"  // HTTPS Everywhere
+    ],
+    
+    "AutofillAddressEnabled": false,
+    "AutofillCreditCardEnabled": false,
+    "BrowserAddPersonEnabled": false,
+    "BrowserSignin": 0,
+    "PasswordManagerEnabled": false
 }

--- a/configs/chromium_policy.json
+++ b/configs/chromium_policy.json
@@ -7,18 +7,18 @@
         "chrome://policy"
     ],
     "ExtensionInstallWhitelist": [
-        "cjpalhdlnbpafiamejdnhcphjbkeiagm", // uBlock Origin
-        "gcbommkclmclpchllfjekcdonpmejbdp", // HTTPS Everywhere
-        "klbibkeccnjlkjkiokjodocebajanakg", // The Great Suspender
-        "eimadpbcbfnmbkopoojfekhnkhdbieeh"  // Dark Reader (optional, 'cause it can break Websites)
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm",
+        "gcbommkclmclpchllfjekcdonpmejbdp",
+        "klbibkeccnjlkjkiokjodocebajanakg",
+        "eimadpbcbfnmbkopoojfekhnkhdbieeh"
     ],
     "ExtensionInstallBlacklist": [
         "*"
     ],
     "ExtensionInstallForcelist": [
-        "cjpalhdlnbpafiamejdnhcphjbkeiagm", // uBlock Origin
-        "klbibkeccnjlkjkiokjodocebajanakg", // The great Suspender
-        "gcbommkclmclpchllfjekcdonpmejbdp"  // HTTPS Everywhere
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm",
+        "klbibkeccnjlkjkiokjodocebajanakg",
+        "gcbommkclmclpchllfjekcdonpmejbdp"
     ],
     
     "AutofillAddressEnabled": false,

--- a/configs/chromium_policy.json
+++ b/configs/chromium_policy.json
@@ -8,19 +8,16 @@
     ],
     "ExtensionInstallWhitelist": [
         "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-        "gcbommkclmclpchllfjekcdonpmejbdp",
-        "klbibkeccnjlkjkiokjodocebajanakg",
-        "eimadpbcbfnmbkopoojfekhnkhdbieeh"
+        "gcbommkclmclpchllfjekcdonpmejbdp"
     ],
     "ExtensionInstallBlacklist": [
         "*"
     ],
     "ExtensionInstallForcelist": [
         "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-        "klbibkeccnjlkjkiokjodocebajanakg",
         "gcbommkclmclpchllfjekcdonpmejbdp"
     ],
-    
+
     "AutofillAddressEnabled": false,
     "AutofillCreditCardEnabled": false,
     "BrowserAddPersonEnabled": false,


### PR DESCRIPTION
I added The Browser Extensions HTTPS Everywhere & The Great suspender for safety and performance respectively and also added Dark Reader as an allowed Plugin. I would've pre-installed Dark-Reader as well, if it wouldn't automatically engage. Dark Reader can break websites, and because of that I wouldn't leave it enabled by default.

I also added a few policies about Autofill and Browser-Users. Autofill and multiple Users aren't required so I disabled them, and I also disabled the browser-wide Google login.