### PR TITLE
Removed window decoration from Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,7 @@ RUN rm -rf src
 COPY ./configs/chromium_policy.json /etc/chromium/policies/managed/policies.json
 # Pulseaudio Configuration
 COPY ./configs/pulse_config.pa /tmp/pulse_config.pa
+# Openbox Configuration
+COPY ./configs/openbox_config.xml /var/lib/openbox/openbox_config.xml
 
 ENTRYPOINT [ "bash", "./start.sh" ]

--- a/configs/openbox_config_.xml
+++ b/configs/openbox_config_.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openbox_config xmlns="http://openbox.org/3.4/rc">
+    <applications>
+        <application class="*">
+            <decor>no</decor>
+        </application>
+    </applications>
+</openbox_config>

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -76,7 +76,7 @@ export default class VirtualBrowser {
 
     // ToDo: Add a communication to the portals WS that the portal is stopping (closed the browser),
     // then stop it after Chromium is closed for a normal shutdown.
-    private setupChromium = () => chromium(this.env, this.startupUrl).on('close', this.setupChromium)
+    private setupChromium = () => chromium(this.env, this.width, this.height, this.startupUrl).on('close', this.setupChromium)
 
     handleControllerEvent = (data: any, type: string) => {
         const command = this.fetchCommand(data, type)

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -25,7 +25,7 @@ export const pulseaudio = (env: NodeJS.ProcessEnv) => spawn('pulseaudio', [
     ]
 })
 
-export const openbox = (env: NodeJS.ProcessEnv) => spawn('openbox', [], {
+export const openbox = (env: NodeJS.ProcessEnv) => spawn('openbox', [ '--config-file=/var/lib/openbox/openbox_config.xml' ], {
     env,
     stdio: [
         'ignore',

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -34,7 +34,7 @@ export const openbox = (env: NodeJS.ProcessEnv) => spawn('openbox', [ '--config-
     ]
 })
 
-export const chromium = (env: NodeJS.ProcessEnv, startupUrl) => {
+export const chromium = (env: NodeJS.ProcessEnv, width: number, height: number, startupUrl) => {
     const config = [
         '-bwsi',
         '-test-type',
@@ -44,7 +44,10 @@ export const chromium = (env: NodeJS.ProcessEnv, startupUrl) => {
         '-force-dark-mode',
         '-disable-file-system',
         '-disable-software-rasterizer',
-    
+
+        '--window-position=0,0',
+        `--window-size=${width},${height}`,
+
         `--display=${env.DISPLAY}`
     ]
 


### PR DESCRIPTION
#20 

This PR removes the window decoration for Chromium (maximize, minimize, and exit buttons).

This also fixes the off-centering and incorrect sizing when you removed the decoration since Chromium doesn't really care about what Openbox wants it to do.