### PR TITLE
Fixed Context Menu instantly closing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ RUN rm -rf src
 
 # Chromium Policies
 COPY ./configs/chromium_policy.json /etc/chromium/policies/managed/policies.json
+# Chromium Preferences
+COPY ./configs/master_preferences.json /etc/chromium/master_preferences
 # Pulseaudio Configuration
 COPY ./configs/pulse_config.pa /tmp/pulse_config.pa
 # Openbox Configuration

--- a/configs/master_preferences.json
+++ b/configs/master_preferences.json
@@ -1,0 +1,5 @@
+{
+  "browser": {
+    "custom_chrome_frame": false
+  }
+}

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -25,7 +25,7 @@ export const pulseaudio = (env: NodeJS.ProcessEnv) => spawn('pulseaudio', [
     ]
 })
 
-export const openbox = (env: NodeJS.ProcessEnv) => spawn('openbox', [ '--config-file=/var/lib/openbox/openbox_config.xml' ], {
+export const openbox = (env: NodeJS.ProcessEnv) => spawn('openbox', [ '--config-file', '/var/lib/openbox/openbox_config.xml' ], {
     env,
     stdio: [
         'ignore',


### PR DESCRIPTION
#49 

Openbox was erroring in debug saying that the command line flag was incorrect which caused unexpected behavior.

After correcting the error, Chromium needed to use the system title bar and borders to have no decoration, so `master_preferences` was added to disable Chromium's custom title bar.